### PR TITLE
Allow test case status and log status to be different

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+robotframework >= 2.8.7

--- a/robotstatuschecker.py
+++ b/robotstatuschecker.py
@@ -96,13 +96,13 @@ class Expected(object):
         self.logs = self._get_logs(doc)
 
     def _get_status(self, doc):
-        return 'FAIL' if 'FAIL' in doc else 'PASS'
+        return 'FAIL' if 'FAIL' in doc.split('LOG', 1)[0] else 'PASS'
 
     def _get_message(self, doc):
         if 'FAIL' not in doc and 'PASS' not in doc:
             return ''
         status = self._get_status(doc)
-        return doc.split(status, 1)[1].split('LOG', 1)[0].strip()
+        return doc.split('LOG', 1)[0].split(status, 1)[-1].strip()
 
     def _get_logs(self, doc):
         return [ExpectedLog(item) for item in doc.split('LOG')[1:]]

--- a/robotstatuschecker.py
+++ b/robotstatuschecker.py
@@ -47,7 +47,7 @@ from robot.api import ExecutionResult, ResultVisitor
 from robot.utils import Matcher
 
 
-__version__ = 'devel'
+__version__ = '1.4'
 
 
 def process_output(inpath, outpath=None, verbose=True):

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,10 @@
+.project
+.pydevproject
+.idea
+test/results
+*.pyc
+*.orig
+*py.class
+MANIFEST
+*.egg-info
+*.egg

--- a/test/tests.robot
+++ b/test/tests.robot
@@ -160,21 +160,22 @@ Test case PASS log INFO
     Log    The message
 
 Test case FAIL log FAIL
-    [Documentation]    FAIL
+    [Documentation]    FAIL The error message
     ...    LOG 2 FAIL The error message
     Status    FAIL    The error message
     Fail    The error message
 
 Test case PASS log FAIL
-    [Documentation]    PASS
-    ...    LOG 2:1 FAIL The error message
+    [Documentation]    PASS The success message
+    ...    LOG 2.1:1 FAIL The error message
     Status    PASS
     Run Keyword And Expect Error
     ...    The error message
     ...    Fail    The error message
+    pass execution    The success message
 
 Test case FAIL log INFO
-    [Documentation]    FAIL
+    [Documentation]    FAIL The error message
     ...    LOG 2 INFO Failing soon!
     Status    FAIL    The error message
     Log    Failing soon!

--- a/test/tests.robot
+++ b/test/tests.robot
@@ -13,6 +13,10 @@ Explicit PASS with message
     Status    PASS    The message
     Pass Execution    The message
 
+Explicit PASS without message
+    [Documentation]    PASS
+    Status    PASS
+
 Expected FAIL
     [Documentation]    FAIL Expected failure
     Status    PASS    Test failed as expected.\n\n
@@ -115,6 +119,18 @@ Expected FAIL and log messages
     Log    Any time now...
     Fail    Told ya!!
 
+Expected FAIL and log messages and no message before FAIL
+    [Documentation]    FAIL Told ya!!
+    ...    LOG 2 Failing soon!
+    ...    LOG 3 Any time now...
+    ...    LOG 4:1 FAIL Told ya!!
+    ...    LOG 4:2 DEBUG STARTS: Traceback
+    Status    PASS    Test failed as expected.\n\n
+    ...    Original message:\nTold ya!!
+    Log    Failing soon!
+    Log    Any time now...
+    Fail    Told ya!!
+
 Expected PASS and log messages
     [Documentation]    This text is ignored. PASS Told ya!!
     ...    LOG 2 Passing soon!
@@ -125,6 +141,44 @@ Expected PASS and log messages
     Log    Passing soon!
     Log    Any time now...
     Pass Execution    Told ya!!
+
+Expected PASS and log messages and no message before PASS
+    [Documentation]    PASS Told ya!!
+    ...    LOG 2 Passing soon!
+    ...    LOG 3 Any time now...
+    ...    LOG 4:1 Execution passed with message:\nTold ya!!
+    ...    LOG 4:2 NONE
+    Status    PASS    Told ya!!
+    Log    Passing soon!
+    Log    Any time now...
+    Pass Execution    Told ya!!
+
+Test case PASS log INFO
+    [Documentation]    PASS
+    ...    LOG 2 INFO The message
+    Status    PASS    The message
+    Log    The message
+
+Test case FAIL log FAIL
+    [Documentation]    FAIL
+    ...    LOG 2 FAIL The error message
+    Status    FAIL    The error message
+    Fail    The error message
+
+Test case PASS log FAIL
+    [Documentation]    PASS
+    ...    LOG 2:1 FAIL The error message
+    Status    PASS
+    Run Keyword And Expect Error
+    ...    The error message
+    ...    Fail    The error message
+
+Test case FAIL log INFO
+    [Documentation]    FAIL
+    ...    LOG 2 INFO Failing soon!
+    Status    FAIL    The error message
+    Log    Failing soon!
+    Fail    The error message
 
 FAILURE: Unexpected PASS
     [Documentation]    FAIL Expected failure does not occur


### PR DESCRIPTION
Small fix to allow different expected statuses for the test case outcome and individual `LOG` messages, which can be different when:

- Running keywords such as `Run Keyword And Expect Error`.
Test case may PASS while the log level is FAIL.
- Checking the log for a passing step on a failing test case.
Test case is FAIL, but the log level is INFO (or some other level).

Fixes issue #4 