### PR TITLE
support rf4 skip status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,12 @@ the word ``FAIL`` (in uppercase) somewhere in the test case
 documentation. The expected error message must then follow
 the ``FAIL`` marker.
 
+For robotframework version 4 you can also change the expected status
+to *SKIP* by adding the word ``SKIP`` in the test case documentation.
+Like Fail, the expected skip message must follow the word ``SKIP``.
+If a test documentation contains the words ``FAIL`` and ``SKIP``, ``SKIP``
+will be ignored and the expected status will be *FAIL*.
+
 If a test is expected to *PASS* with a certain message, the word
 ``PASS`` must be added to its documentation explicitly and the
 expected message given after that.

--- a/robotstatuschecker.py
+++ b/robotstatuschecker.py
@@ -93,10 +93,17 @@ class Expected:
         self.logs = self._get_logs(doc)
 
     def _get_status(self, doc):
-        return "FAIL" if "FAIL" in doc else "PASS"
+        if RF3:
+            return "FAIL" if "FAIL" in doc else "PASS"
+        if "FAIL" not in doc:
+            return "SKIP" if "SKIP" in doc else "PASS"
+        return "FAIL"
 
     def _get_message(self, doc):
-        if "FAIL" not in doc and "PASS" not in doc:
+        if RF3:
+            if "FAIL" not in doc and "PASS" not in doc:
+                return ""
+        if all(status not in doc for status in ["FAIL", "SKIP", "PASS"]):
             return ""
         status = self._get_status(doc)
         return doc.split(status, 1)[1].split("LOG", 1)[0].strip()

--- a/test/README.rst
+++ b/test/README.rst
@@ -17,3 +17,12 @@ other tests should pass.
 Test statuses and messages set by StatusChecker are verified by ``run.py``.
 Expected statuses and messages are logged by ``Status`` keyword that all
 tests must use as their first keyword.
+
+Test cases that use features only available in RF4+ (e.g. SKIP status) should
+be tagged with
+
+.. sourcecode:: robotframework
+   
+        [Tags]    rf3unsupported
+
+and will be excluded in run.py if the installed robotframework is RF3.

--- a/test/run.py
+++ b/test/run.py
@@ -32,7 +32,10 @@ def _run_tests_and_process_output(robot_file):
     output = join(results, "output.xml")
     if exists(results):
         rmtree(results)
-    run(join(CURDIR, robot_file), output=output, log=None, report=None, loglevel="DEBUG")
+    if RF3:
+        run(join(CURDIR, robot_file), output=output, log=None, report=None, loglevel="DEBUG", exclude="rf3unsupported")
+    else: 
+        run(join(CURDIR, robot_file), output=output, log=None, report=None, loglevel="DEBUG")
     process_output(output)
     rebot(output, outputdir=results)
     return output
@@ -82,7 +85,10 @@ class StatusCheckerChecker(ResultVisitor):
             print("%d/%d test failed:" % (len(self.errors), self.tests))
             print("\n-------------------------------------\n".join(self.errors))
         else:
-            print("All %d tests passed/failed/logged as expected." % self.tests)
+            if RF3:
+                print("All %d tests passed/failed/logged as expected." % self.tests)
+            else: 
+                print("All %d tests passed/failed/logged/skipped as expected." % self.tests)
         print("Run on %s %s." % (python_implementation(), python_version()))
 
 

--- a/test/tests.robot
+++ b/test/tests.robot
@@ -12,11 +12,31 @@ Explicit PASS with message
     Status    PASS    The message
     Pass Execution    The message
 
+Explicit SKIP with message
+    [Documentation]   SKIP The message
+    [Tags]    rf3unsupported
+    Status    SKIP    The message
+    Skip    The message
+
 Expected FAIL
     [Documentation]    FAIL Expected failure
     Status    PASS    Test failed as expected.\n\n
     ...    Original message:\nExpected failure
     Fail    Expected failure
+
+SKIP Plus FAIL Expected FAIL
+    [Documentation]    SKIP FAIL Expected failure
+    [Tags]    rf3unsupported
+    Status    PASS    Test failed as expected.\n\n
+    ...    Original message:\nExpected failure
+    Fail    Expected failure
+
+FAIL Plus SKIP Expected FAIL
+    [Documentation]    FAIL Expected failure SKIP
+    [Tags]    rf3unsupported
+    Status    PASS    Test failed as expected.\n\n
+    ...    Original message:\nExpected failure SKIP
+    Fail    Expected failure SKIP
 
 Ignore documentation before marker
     [Documentation]    This text is ignored. FAIL Expected failure


### PR DESCRIPTION
### Change:
Allow for setting *SKIP* expected status in RF4 the same way you can for *FAIL* and *PASS*.
See updated **README**

#### Testing performed: 
ran tests/run.py with 3 test cases added for expected `SKIP` status results (excluded by tag if RF3)
##### RF4 and RF3 `tests/run.py` output:

**RF4:**
<details>
  <summary>[click to expand full test output!]</summary>

```
==============================================================================
Tests                                                                         
==============================================================================
Implicit PASS                                                         | PASS |
------------------------------------------------------------------------------
Explicit PASS with message :: PASS The message                        | PASS |
The message
------------------------------------------------------------------------------
Explicit SKIP with message :: SKIP The message                        | SKIP |
The message
------------------------------------------------------------------------------
Expected FAIL :: FAIL Expected failure                                | FAIL |
Expected failure
------------------------------------------------------------------------------
SKIP Plus FAIL Expected FAIL :: SKIP FAIL Expected failure            | FAIL |
Expected failure
------------------------------------------------------------------------------
FAIL Plus SKIP Expected FAIL :: FAIL Expected failure SKIP            | FAIL |
Expected failure SKIP
------------------------------------------------------------------------------
Ignore documentation before marker :: This text is ignored. FAIL E... | FAIL |
Expected failure
------------------------------------------------------------------------------
Expected FAIL with REGEXP :: FAIL REGEXP: Pattern is here.* \d+       | FAIL |
Pattern is here
multiline 123
------------------------------------------------------------------------------
Expected FAIL with GLOB :: FAIL GLOB: Globs ??? way *wl even *!?!     | FAIL |
Globs are way kewl
even in multile lines
!!!
------------------------------------------------------------------------------
Expected FAIL with STARTS :: FAIL STARTS: This is start               | FAIL |
This is start and this is end
------------------------------------------------------------------------------
Log message :: LOG 2 Hello world!                                     | PASS |
------------------------------------------------------------------------------
Log message with message index :: LOG 2:1 Hello LOG 2:2 world LOG ... | PASS |
------------------------------------------------------------------------------
Log messages with levels :: LOG 2 DEBUG Hello LOG 3 WARN World LOG... [ WARN ] World
[ ERROR ] Tidii
| PASS |
------------------------------------------------------------------------------
Trailing and leading whitespace is ignored in log messages :: LOG ... | PASS |
------------------------------------------------------------------------------
Log messages deeper :: LOG 2:1 Hello LOG 2:2 World LOG 3.1 DEBUG U... | PASS |
------------------------------------------------------------------------------
Log messages deeper with setup :: LOG 1:1 Hello LOG 1:2 World LOG ... | PASS |
------------------------------------------------------------------------------
Log messages deeper with wildcard :: LOG 2:1 Hello LOG 2:2 ANY Wor... | PASS |
------------------------------------------------------------------------------
Log messages deeper with wildcard and setup :: LOG 1:1 Hello LOG 1... | PASS |
------------------------------------------------------------------------------
Log message with REGEXP :: LOG 2 REGEXP: H[ei]l{2}o w\w+! LOG 2 RE... | PASS |
------------------------------------------------------------------------------
Log message with GLOB :: LOG 2 GLOB: *world! LOG 2 GLOB: Hell? ***!   | PASS |
------------------------------------------------------------------------------
Log message with STARTS :: LOG 2 STARTS: Hello LOG 2 STARTS: Hell ... | PASS |
------------------------------------------------------------------------------
NONE log message :: LOG 2 NONE LOG 2:1 NONE LOG 3:1 Message LOG 3:... | PASS |
------------------------------------------------------------------------------
Test Setup Check Is Done By SETUP Marker :: ... LOG SETUP:1 NONE L... | PASS |
------------------------------------------------------------------------------
Error When No Setup :: ... LOG SETUP.1:1 PASS LOG 2:1 KALA            | PASS |
------------------------------------------------------------------------------
Test Setup Check Is Done By SETUP Marker and wildcard is used :: .... | PASS |
------------------------------------------------------------------------------
Error When No Setup and wildcard is used :: ... LOG SETUP.1:* PASS... | PASS |
------------------------------------------------------------------------------
Test Teardown Check Is Done By TEARDOWN Marker :: ... LOG TEARDOWN... | PASS |
------------------------------------------------------------------------------
Error When No Teardown :: LOG TEARDOWN:1 foobar                       | PASS |
------------------------------------------------------------------------------
Test Teardown Check Is Done By TEARDOWN Marker and wildcard is use... | PASS |
------------------------------------------------------------------------------
Error When No Teardown and wildcard is used :: LOG TEARDOWN:* foobar  | PASS |
------------------------------------------------------------------------------
Error When NONE is used with wildcard :: LOG 2.1:* INFO NONE          | PASS |
------------------------------------------------------------------------------
Expected FAIL and log messages :: This text is ignored. FAIL Told ... | FAIL |
Told ya!!
------------------------------------------------------------------------------
Expected PASS and log messages :: This text is ignored. PASS Told ... | PASS |
Told ya!!
------------------------------------------------------------------------------
Expected PASS and teadown does not affect :: This text is ignored.... | PASS |
------------------------------------------------------------------------------
FAILURE: Unexpected PASS :: FAIL Expected failure does not occur      | PASS |
------------------------------------------------------------------------------
FAILURE: Wrong PASS message                                           | PASS |
Unexpected message
------------------------------------------------------------------------------
FAILURE: Unexpected FAIL                                              | FAIL |
Unexpected error message
------------------------------------------------------------------------------
FAILURE: Wrong message :: FAIL Expected failure                       | FAIL |
Not the expected message
------------------------------------------------------------------------------
FAILURE: Wrong log message :: LOG 2 Hello world!                      | PASS |
------------------------------------------------------------------------------
FAILURE: Wrong log level :: LOG 2.1 Hello world!                      | PASS |
------------------------------------------------------------------------------
FAILURE: Unexpected log message :: LOG 2.1:2 NONE                     | PASS |
------------------------------------------------------------------------------
FAILURE: Non-existing keyword :: LOG 2 No keyword here                | PASS |
------------------------------------------------------------------------------
FAILURE: Non-existing log message :: LOG 2:2 No message here          | PASS |
------------------------------------------------------------------------------
FAILURE: Non-existing log message wildcard :: LOG 1:* Bogus message   | PASS |
------------------------------------------------------------------------------
Tests                                                                 | FAIL |
44 tests, 33 passed, 10 failed, 1 skipped
==============================================================================
Output:  /Users/ejones/Documents/workspace/statuschecker/test/results/output.xml
Checking /Users/ejones/Documents/workspace/statuschecker/test/results/output.xml
Log:     /Users/ejones/Documents/workspace/statuschecker/test/results/log.html
Report:  /Users/ejones/Documents/workspace/statuschecker/test/results/report.html

All 44 tests passed/failed/logged/skipped as expected.
Run on CPython 3.9.7.
Robot Framework version: 4.0
```
</details>

```
yes|pip uninstall robotframework && pip install robotframework==4; python test/run.py
[...]
All 44 tests passed/failed/logged/skipped as expected.
Run on CPython 3.9.7.
Robot Framework version: 4.0
```


**RF3:**
<details>
  <summary>  [click to expand full test output!] </summary>
  
```
==============================================================================
Tests                                                                         
==============================================================================
Implicit PASS                                                         | PASS |
------------------------------------------------------------------------------
Explicit PASS with message :: PASS The message                        | PASS |
The message
------------------------------------------------------------------------------
Expected FAIL :: FAIL Expected failure                                | FAIL |
Expected failure
------------------------------------------------------------------------------
Ignore documentation before marker :: This text is ignored. FAIL E... | FAIL |
Expected failure
------------------------------------------------------------------------------
Expected FAIL with REGEXP :: FAIL REGEXP: Pattern is here.* \d+       | FAIL |
Pattern is here
multiline 123
------------------------------------------------------------------------------
Expected FAIL with GLOB :: FAIL GLOB: Globs ??? way *wl               | FAIL |
Globs are way kewl
even in multile lines
!!!
------------------------------------------------------------------------------
Expected FAIL with STARTS :: FAIL STARTS: This is start               | FAIL |
This is start and this is end
------------------------------------------------------------------------------
Log message :: LOG 2 Hello world!                                     | PASS |
------------------------------------------------------------------------------
Log message with message index :: LOG 2:1 Hello LOG 2:2 world LOG ... | PASS |
------------------------------------------------------------------------------
Log messages with levels :: LOG 2 DEBUG Hello                         [ WARN ] World
[ ERROR ] Tidii
| PASS |
------------------------------------------------------------------------------
Trailing and leading whitespace is ignored in log messages :: LOG ... | PASS |
------------------------------------------------------------------------------
Log messages deeper :: LOG 2:1 Hello                                  | PASS |
------------------------------------------------------------------------------
Log messages deeper with setup :: LOG 1:1 Hello                       | PASS |
------------------------------------------------------------------------------
Log messages deeper with wildcard :: LOG 2:1 Hello                    | PASS |
------------------------------------------------------------------------------
Log messages deeper with wildcard and setup :: LOG 1:1 Hello          | PASS |
------------------------------------------------------------------------------
Log message with REGEXP :: LOG 2 REGEXP: H[ei]l{2}o w\w+! LOG 2 RE... | PASS |
------------------------------------------------------------------------------
Log message with GLOB :: LOG 2 GLOB: *world! LOG 2 GLOB: Hell? ***!   | PASS |
------------------------------------------------------------------------------
Log message with STARTS :: LOG 2 STARTS: Hello LOG 2 STARTS: Hell     | PASS |
------------------------------------------------------------------------------
NONE log message :: LOG 2 NONE LOG 2:1 NONE LOG 3:1 Message LOG 3:... | PASS |
------------------------------------------------------------------------------
Test Setup Check Is Done By SETUP Marker :: LOG SETUP:1 NONE          | PASS |
------------------------------------------------------------------------------
Error When No Setup :: LOG SETUP.1:1 PASS                             | PASS |
------------------------------------------------------------------------------
Test Setup Check Is Done By SETUP Marker and wildcard is used :: L... | PASS |
------------------------------------------------------------------------------
Error When No Setup and wildcard is used :: LOG SETUP.1:* PASS        | PASS |
------------------------------------------------------------------------------
Test Teardown Check Is Done By TEARDOWN Marker :: LOG TEARDOWN:1 f... | PASS |
------------------------------------------------------------------------------
Error When No Teardown :: LOG TEARDOWN:1 foobar                       | PASS |
------------------------------------------------------------------------------
Test Teardown Check Is Done By TEARDOWN Marker and wildcard is use... | PASS |
------------------------------------------------------------------------------
Error When No Teardown and wildcard is used :: LOG TEARDOWN:* foobar  | PASS |
------------------------------------------------------------------------------
Error When NONE is used with wildcard :: LOG 2.1:* INFO NONE          | PASS |
------------------------------------------------------------------------------
Expected FAIL and log messages :: This text is ignored. FAIL Told ... | FAIL |
Told ya!!
------------------------------------------------------------------------------
Expected PASS and log messages :: This text is ignored. PASS Told ... | PASS |
Told ya!!
------------------------------------------------------------------------------
Expected PASS and teadown does not affect :: This text is ignored.    | PASS |
------------------------------------------------------------------------------
FAILURE: Unexpected PASS :: FAIL Expected failure does not occur      | PASS |
------------------------------------------------------------------------------
FAILURE: Wrong PASS message                                           | PASS |
Unexpected message
------------------------------------------------------------------------------
FAILURE: Unexpected FAIL                                              | FAIL |
Unexpected error message
------------------------------------------------------------------------------
FAILURE: Wrong message :: FAIL Expected failure                       | FAIL |
Not the expected message
------------------------------------------------------------------------------
FAILURE: Wrong log message :: LOG 2 Hello world!                      | PASS |
------------------------------------------------------------------------------
FAILURE: Wrong log level :: LOG 2.1 Hello world!                      | PASS |
------------------------------------------------------------------------------
FAILURE: Unexpected log message :: LOG 2.1:2 NONE                     | PASS |
------------------------------------------------------------------------------
FAILURE: Non-existing keyword :: LOG 2 No keyword here                | PASS |
------------------------------------------------------------------------------
FAILURE: Non-existing log message :: LOG 2:2 No message here          | PASS |
------------------------------------------------------------------------------
FAILURE: Non-existing log message wildcard :: LOG 1:* Bogus message   | PASS |
------------------------------------------------------------------------------
Tests                                                                 | FAIL |
41 critical tests, 33 passed, 8 failed
41 tests total, 33 passed, 8 failed
==============================================================================
Output:  /Users/ejones/Documents/workspace/statuschecker/test/results/output.xml
Checking /Users/ejones/Documents/workspace/statuschecker/test/results/output.xml
Log:     /Users/ejones/Documents/workspace/statuschecker/test/results/log.html
Report:  /Users/ejones/Documents/workspace/statuschecker/test/results/report.html

All 41 tests passed/failed/logged as expected.
Run on CPython 3.9.7.
Robot Framework version: 3.0
```
</details>

```
yes|pip uninstall robotframework && pip install robotframework==3; python test/run.py
[...]
All 41 tests passed/failed/logged as expected.
Run on CPython 3.9.7.
Robot Framework version: 3.0
```