### PR TITLE
fix skip status support

### DIFF
--- a/robotstatuschecker.py
+++ b/robotstatuschecker.py
@@ -211,15 +211,18 @@ class TestStatusChecker(BaseChecker):
 
     def _check_status(self, test):
         condition = test.status == self.status
-        message = f"Test was expected to {self.status} but it {test.status}ED."
+        message = "Test was expected to {} but it {}.".format(self.status,
+            "SKIPPED" if test.status == "SKIP" else test.status + "ED")
         return self._assert(condition, test, message)
 
     def _check_message(self, test):
         if not self._message_matches(test.message, self.message):
             message = f"Wrong message.\n\nExpected:\n{self.message}"
             return self._fail(test, message)
-        if test.status == "FAIL":
-            return self._pass(test, "Test failed as expected.")
+        if test.status != "PASS":
+            return self._pass(test, "Test {} as expected.".format(
+                "skipped" if test.status == "SKIP" else test.status.lower()+"ed"
+            ))
         return True
 
 

--- a/test/tests.robot
+++ b/test/tests.robot
@@ -15,7 +15,8 @@ Explicit PASS with message
 Explicit SKIP with message
     [Documentation]   SKIP The message
     [Tags]    rf3unsupported
-    Status    SKIP    The message
+    Status    PASS    Test skipped as expected.\n\n
+    ...    Original message:\nThe message
     Skip    The message
 
 Expected FAIL
@@ -277,6 +278,12 @@ FAILURE: Unexpected PASS
     Status    FAIL    Test was expected to FAIL but it PASSED.
     No Operation
 
+FAILURE: Unexpected PASS for Expected SKIP
+    [Documentation]    SKIP Expected skip does not occur
+    [Tags]    rf3unsupported
+    Status    FAIL    Test was expected to SKIP but it PASSED.
+    No Operation
+
 FAILURE: Wrong PASS message
     Status    FAIL    Wrong message.\n\n
     ...    Expected:\n\n\n
@@ -288,6 +295,26 @@ FAILURE: Unexpected FAIL
     ...    Original message:\n
     ...    Unexpected error message
     Fail    Unexpected error message
+
+FAILURE: Unexpected FAIL for Expected SKIP
+    [Documentation]    SKIP
+    [Tags]    rf3unsupported
+    Status    FAIL    Test was expected to SKIP but it FAILED.\n\n
+    ...  Original message:\nSomething Bad Happened
+    Fail    Something Bad Happened
+
+FAILURE: Unexpected SKIP
+    [Tags]    rf3unsupported
+    Status    FAIL    Test was expected to PASS but it SKIPPED.\n\n
+    ...    Original message:\nSkipped with Skip keyword.
+    SKIP
+
+FAILURE: Unexpected SKIP for Expected FAIL
+    [Documentation]    FAIL
+    [Tags]    rf3unsupported
+    Status    FAIL    Test was expected to FAIL but it SKIPPED.\n\n
+    ...    Original message:\nSkipped with Skip keyword.
+    SKIP
 
 FAILURE: Wrong message
     [Documentation]    FAIL Expected failure


### PR DESCRIPTION
Small change to correct handling of SKIP in RSC. Original PR from me did not make tests that have SKIP in the doc pass when they indeed SKIP as expected.